### PR TITLE
Fix Select Multiple bug (leave last option even not selected)

### DIFF
--- a/js/jquery.nice-select-with-search-multiple.js
+++ b/js/jquery.nice-select-with-search-multiple.js
@@ -74,6 +74,11 @@ Made by Hernán Sartorio  */
                     $selected_text = $selected_option.data('display') ||  $selected_option.text();
                     $selected_html += '<span class="current">' + $selected_text + '</span>';
                 });
+                
+                if ($dropdown.find('.selected').length < 1) {
+                    $('span.multiple-options').html('');
+                }
+                
                 $select_placeholder = $select.data('placeholder') || $select.attr('placeholder');
                 $select_placeholder = $select_placeholder == '' ? 'Select' : $select_placeholder;
                 $selected_html = $selected_html == '' ? $select_placeholder : $selected_html;


### PR DESCRIPTION
Step to reproduce (before this fix)
1. Use select multiple with nice select,
2. Pick the Option
3. Remove Selected option (one by one)
4. Last Option can't be removed even already been toggled